### PR TITLE
cmake now uses platformindependent cp, fixes #14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if (AALWINES_GetDependencies)
         URL_HASH SHA512=6c10583e6631ccdb0217d0a5381172cb4c1046226de6ef1acf398d85e81d145228e14c3016aefcd7b70a1db8631505b048d8b4f5d4b0dbf1811d2482eefdd265
         BUILD_COMMAND ""
         CONFIGURE_COMMAND ""
-        INSTALL_COMMAND cp -f ../rapidxml-ext/{rapidxml,rapidxml_iterators,rapidxml_print,rapidxml_utils}.hpp ${EXTERNAL_INSTALL_LOCATION}/include 
+        INSTALL_COMMAND cd ../rapidxml-ext && ${CMAKE_COMMAND} -E copy rapidxml.hpp rapidxml_iterators.hpp rapidxml_print.hpp rapidxml_utils.hpp ${EXTERNAL_INSTALL_LOCATION}/include 
     )
 
     # we can now include external libraries


### PR DESCRIPTION
Using platform independent "cmake -E copy" insted of cp command
for copying rapidxml files