### PR TITLE
Fix bug in query builder that gives incorrect results

### DIFF
--- a/src/aalwines/query/QueryBuilder.cpp
+++ b/src/aalwines/query/QueryBuilder.cpp
@@ -176,7 +176,7 @@ namespace aalwines
         filter_t res;
         if(!_post && !_link)
         {
-            res._from = [&](const char* name)
+            res._from = [str](const char* name)
             {
                 return (str.compare(name) == 0);
             };


### PR DESCRIPTION
A string from the parser was used by reference in a lambda to compare to router names, but when the comparison happens the referenced string has changed resulting in a logic error. This gives incorrect results for queries like: <.> [.#Router1] [Router1#Router2] [Router2#.] <.> 0
(giving false, even though there exists a suitable hop from Router1 to Router2.)