### PR TITLE
add meta information to the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ cmake-build-debug/
 cmake-build-release/
 src/aalwines/query/*.cc
 src/aalwines/query/*.hh
+
+cmake-build-profiler/
+
+cmake-build-static/
+
+test/results/

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,7 @@ cmake-build-release/
 src/aalwines/query/*.cc
 src/aalwines/query/*.hh
 
+# Test
 cmake-build-profiler/
-
 cmake-build-static/
-
 test/results/

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -136,6 +136,9 @@ int main(int argc, const char** argv)
     bool no_timing = false;
     std::string topology_destination;
     std::string routing_destination;
+    static const char *engineTypes[] = {"", "Moped", "Post*", "Pre*"};
+    static const char *modeTypes[] {"OVER", "UNDER", "DUAL", "EXACT"};
+    Query::mode_t mode;
 
     output.add_options()
             ("dot", po::bool_switch(&print_dot), "A dot output will be printed to cout when set.")
@@ -390,6 +393,7 @@ int main(int argc, const char** argv)
                 if(result == utils::MAYBE && m == Query::OVER && !engine_outcome)
                     result = utils::NO;
                 if(result != utils::MAYBE)
+                    mode = m;
                     break;
                 /*else
                     trace.clear();*/
@@ -412,6 +416,8 @@ int main(int argc, const char** argv)
                 break;
             }
             std::cout << ",\n";
+            std::cout << "\t\t\"engine\":" << engineTypes[engine] << ", " << std::endl;
+            std::cout << "\t\t\"mode\":" << modeTypes[mode] << ", " << std::endl;
             std::cout << "\t\t\"reduction\":[" << reduction.first << ", " << reduction.second << "]";
             if(get_trace && result == utils::YES)
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,6 @@ int main(int argc, const char** argv)
     std::string routing_destination;
     static const char *engineTypes[] = {"", "Moped", "Post*", "Pre*"};
     static const char *modeTypes[] {"OVER", "UNDER", "DUAL", "EXACT"};
-    Query::mode_t mode;
 
     output.add_options()
             ("dot", po::bool_switch(&print_dot), "A dot output will be printed to cout when set.")
@@ -366,6 +365,7 @@ int main(int argc, const char** argv)
             else
             {
             std::vector<Query::mode_t> modes{q.approximation()};
+            Query::mode_t mode = q.approximation();
             bool was_dual = q.approximation() == Query::DUAL;
             if(was_dual)
                 modes = std::vector<Query::mode_t>{Query::OVER, Query::UNDER};


### PR DESCRIPTION
#49 This resolves the issue of missing meta-information on the output. It includes engine and mode.