### PR TITLE
Custom weights on forwarding rules

### DIFF
--- a/src/aalwines/model/NetworkPDAFactory.h
+++ b/src/aalwines/model/NetworkPDAFactory.h
@@ -381,7 +381,7 @@ namespace aalwines {
             if (forward._ops.size() <= 1) {
                 res = add_state(n, forward._via->match(), appmode);
                 if constexpr (is_weighted) {
-                    ar._weight = _weight_f(forward, true);
+                    ar._weight = _weight_f(forward);
                 }
             } else {
                 auto eid = ((&entry) - s._inf->table().entries().data());
@@ -473,7 +473,7 @@ namespace aalwines {
                 auto res = add_state(s._nfastate, r._via->match(), s._appmode);
                 nr._dest = res.second;
                 if constexpr (is_weighted) {
-                    nr._weight = _weight_f(r, true);
+                    nr._weight = _weight_f(r);
                 }
             } else {
                 auto res = add_state(s._nfastate, s._inf, s._appmode, s._eid, s._rid, s._opid + 1);
@@ -506,7 +506,7 @@ namespace aalwines {
 
         if constexpr (is_weighted) {
             stream << ", \"priority-weight\": [";
-            auto weights = _weight_f(rule, true);
+            auto weights = _weight_f(rule);
             for (size_t v = 0; v < weights.size(); v++){
                 if (v != 0) stream << ", ";
                 stream << "\"" << std::to_string(weights[v]) << "\"";

--- a/src/aalwines/model/NetworkWeight.h
+++ b/src/aalwines/model/NetworkWeight.h
@@ -52,10 +52,10 @@ namespace aalwines {
      */
     class NetworkWeight {
     private:
-        using atomic_property_function = std::function<uint32_t(const RoutingTable::forward_t&, bool)>;
-        using linear_weight_function = pdaaal::linear_weight_function<uint32_t, const RoutingTable::forward_t&, bool>;
+        using atomic_property_function = std::function<uint32_t(const RoutingTable::forward_t&)>;
+        using linear_weight_function = pdaaal::linear_weight_function<uint32_t, const RoutingTable::forward_t&>;
     public:
-        using weight_function = pdaaal::ordered_weight_function<uint32_t, const RoutingTable::forward_t&, bool>;
+        using weight_function = pdaaal::ordered_weight_function<uint32_t, const RoutingTable::forward_t&>;
 
         enum class AtomicProperty {
             default_weight_function,
@@ -73,38 +73,36 @@ namespace aalwines {
         [[nodiscard]] atomic_property_function get_atom(AtomicProperty atom) const {
             switch (atom) {
                 case AtomicProperty::link_failures:
-                    return [](const RoutingTable::forward_t& r, bool _) -> uint32_t {
+                    return [](const RoutingTable::forward_t& r) -> uint32_t {
                         return r._weight;
                     };
                 case AtomicProperty::number_of_hops:
-                    return [](const RoutingTable::forward_t& r, bool last_op) -> uint32_t {
-                        return last_op && !r._via->is_virtual() ? 1 : 0;
+                    return [](const RoutingTable::forward_t& r) -> uint32_t {
+                        return !r._via->is_virtual() ? 1 : 0;
                     };
                 case AtomicProperty::tunnels:
-                    return [](const RoutingTable::forward_t& r, bool _) -> uint32_t {
+                    return [](const RoutingTable::forward_t& r) -> uint32_t {
                         return std::count_if(r._ops.begin(), r._ops.end(), [](RoutingTable::action_t act) -> bool { return act._op == RoutingTable::op_t::PUSH; });
                     };
                 case AtomicProperty::distance:
-                    return [](const RoutingTable::forward_t& r, bool last_op) -> uint32_t {
-                        if (!last_op) return 0;
+                    return [](const RoutingTable::forward_t& r) -> uint32_t {
                         return r._via->source()->coordinate() && r._via->target()->coordinate()
                                ? r._via->source()->coordinate()->distance_to(r._via->target()->coordinate().value())
                                : 20038; //(km). If coordinates are missing, use half circumference of earth, i.e. worst case distance.
                     };
                 case AtomicProperty::custom:
-                    return [](const RoutingTable::forward_t& r, bool _) -> uint32_t {
+                    return [](const RoutingTable::forward_t& r) -> uint32_t {
                         return r._custom_weight;
                     };
                 case AtomicProperty::latency:
-                    return [this](const RoutingTable::forward_t& r, bool last_op) -> uint32_t {
-                        if (!last_op) return 0;
+                    return [this](const RoutingTable::forward_t& r) -> uint32_t {
                         auto it = this->_latency_map.find(r._via);
                         return it != this->_latency_map.end() ? it->second : 0;
                         // (r._via->source()->index(), r._via->target()->index())
                     };
                 case AtomicProperty::default_weight_function:
                 default:
-                    return [](const RoutingTable::forward_t& r, bool _) -> uint32_t {
+                    return [](const RoutingTable::forward_t& r) -> uint32_t {
                         return 0;
                     };
             }
@@ -129,7 +127,7 @@ namespace aalwines {
         }
 
         static auto default_weight_fn() {
-            return pdaaal::ordered_weight_function(std::vector<linear_weight_function>{linear_weight_function{[](const RoutingTable::forward_t& r, bool _) -> uint32_t {
+            return pdaaal::ordered_weight_function(std::vector<linear_weight_function>{linear_weight_function{[](const RoutingTable::forward_t& r) -> uint32_t {
                 return 0;
             }}});
         }

--- a/src/aalwines/model/NetworkWeight.h
+++ b/src/aalwines/model/NetworkWeight.h
@@ -47,7 +47,7 @@ namespace aalwines {
      *   ], ...
      * ]
      * where
-     *  - ATOM = {"hops", "failures", "tunnels", "distance", "latency", "zero"}
+     *  - ATOM = {"hops", "failures", "tunnels", "distance", "custom", "latency", "zero"}
      *  - NUM = {0,1,2,...}
      */
     class NetworkWeight {
@@ -63,6 +63,7 @@ namespace aalwines {
             number_of_hops,
             tunnels,
             distance,
+            custom,
             latency,
         };
 
@@ -89,6 +90,10 @@ namespace aalwines {
                         return r._via->source()->coordinate() && r._via->target()->coordinate()
                                ? r._via->source()->coordinate()->distance_to(r._via->target()->coordinate().value())
                                : 20038; //(km). If coordinates are missing, use half circumference of earth, i.e. worst case distance.
+                    };
+                case AtomicProperty::custom:
+                    return [](const RoutingTable::forward_t& r, bool _) -> uint32_t {
+                        return r._custom_weight;
                     };
                 case AtomicProperty::latency:
                     return [this](const RoutingTable::forward_t& r, bool last_op) -> uint32_t {
@@ -148,6 +153,8 @@ namespace aalwines {
                 p = AtomicProperty::tunnels;
             } else if (s == "distance") {
                 p = AtomicProperty::distance;
+            } else if (s == "custom") {
+                p = AtomicProperty::custom;
             } else if (s == "latency") {
                 p = AtomicProperty::latency;
             } else if (s == "zero") {

--- a/src/aalwines/model/RoutingTable.h
+++ b/src/aalwines/model/RoutingTable.h
@@ -68,6 +68,7 @@ namespace aalwines {
             std::vector<action_t> _ops;
             Interface* _via = nullptr;
             size_t _weight = 0;
+            uint32_t _custom_weight = 0;
             forward_t() = default;
             forward_t(type_t type, std::vector<action_t> ops, Interface* via, size_t weight)
                 : _type(type), _ops(std::move(ops)), _via(via), _weight(weight) {};

--- a/src/aalwines/model/builders/PRexBuilder.cpp
+++ b/src/aalwines/model/builders/PRexBuilder.cpp
@@ -388,6 +388,11 @@ namespace aalwines {
                                     entry._rules.back()._type = RoutingTable::MPLS;
                                     entry._rules.back()._weight = weight;
 
+                                    auto custom_weight = route->first_attribute("weight");
+                                    if (custom_weight != nullptr) {
+                                        entry._rules.back()._custom_weight = std::stoul(custom_weight->value());
+                                    }
+
                                     if(entry._rules.back()._via == nullptr)
                                     {
                                         es << "Could not match find \"to\" with interface on " << router->name() << "attribute in <route>-tag : " << toattr->value();


### PR DESCRIPTION
Allows specifying a custom weight in the routing.xml file using a new weight attribute in the \<route\> tag.
Example: \<route to="Miami" weight="1"\>
The weight is parsed to a uint32_t value. 
The new atom "custom" in the weight-json file will use this value.

(PR also cleans up a bit.)