### PR TITLE
Trace outputs links with from and to router and interface names

### DIFF
--- a/src/aalwines/model/NetworkPDAFactory.h
+++ b/src/aalwines/model/NetworkPDAFactory.h
@@ -703,8 +703,8 @@ namespace aalwines {
                         if (!first_symbol)
                             stream << ",";
                         stream << "\"" << symbol;
-                        if (_network.is_service_label(symbol))
-                            stream << "^";
+                        //if (_network.is_service_label(symbol))
+                        //    stream << "^";
                         stream << "\"";
                         first_symbol = false;
                     }

--- a/src/aalwines/model/NetworkPDAFactory.h
+++ b/src/aalwines/model/NetworkPDAFactory.h
@@ -684,11 +684,19 @@ namespace aalwines {
                 } else {
                     if (!first)
                         stream << ",\n";
-                    stream << "\t\t\t{\"router\":";
-                    if (s._inf)
-                        stream << "\"" << s._inf->source()->name() << "\"";
-                    else
-                        stream << "null";
+                    stream << "\t\t\t{";
+                    assert(s._inf != nullptr);
+                    auto from_inf = s._inf->match();
+                    auto from_router = s._inf->target();
+                    auto to_inf = s._inf;
+                    auto to_router = s._inf->source();
+                    assert(from_inf != nullptr);
+                    assert(from_router != nullptr);
+                    assert(to_router != nullptr);
+                    stream << R"("from_router":")" << from_router->name() << "\""
+                           << R"(,"from_interface":")" << from_router->interface_name(from_inf->id()).get() << "\""
+                           << R"(,"to_router":")" << to_router->name() << "\""
+                           << R"(,"to_interface":")" << to_router->interface_name(to_inf->id()).get() << "\"";
                     stream << ",\"stack\":[";
                     bool first_symbol = true;
                     for (auto &symbol : step._stack) {

--- a/src/aalwines/model/Query.h
+++ b/src/aalwines/model/Query.h
@@ -157,7 +157,7 @@ namespace aalwines {
                 switch(label._type)
                 {
                     case STICKY_MPLS:
-                        stream << "$";
+                        stream << "s";
                     case MPLS:
                         if(label._mask >= 64 || label == Query::label_t::unused_mpls || label == Query::label_t::unused_sticky_mpls)
                             stream << "mpls";


### PR DESCRIPTION
Example of a trace with the new formating: 
```json 
"trace":[
			{"from_router":"NULL","from_interface":"i41","to_router":"Stockton","to_interface":"iStockton","stack":["1599^"]},
			{"ingoing":"iStockton","pre":"1599^","rule":{"weight":0, "via":"Santa_Clara", "ops":[{"swap":"1600"}]}},
			{"from_router":"Stockton","from_interface":"Santa_Clara","to_router":"Santa_Clara","to_interface":"Stockton","stack":["1600"]},
			{"ingoing":"Stockton","pre":"1600","rule":{"weight":0, "via":"Los_Angeles", "ops":[{"swap":"1601"}]}},
			{"from_router":"Santa_Clara","from_interface":"Los_Angeles","to_router":"Los_Angeles","to_interface":"Santa_Clara","stack":["1601"]}
		]
```