### PR TITLE
Single quote names

### DIFF
--- a/src/aalwines/query/QueryLexer.l
+++ b/src/aalwines/query/QueryLexer.l
@@ -39,7 +39,7 @@ using token = aalwines::Parser::token;
 
 %option noyywrap nounput batch noinput c++
 %option yyclass="aalwines::Scanner"
-%x comment
+%x comment S_STRING
 
 id    [a-zA-Z\_\-][a-zA-Z0-9\_\-]*
 hex   [0-9a-fA-F]
@@ -47,7 +47,6 @@ int   [0-9]+
 float {int}*\.{int}+
 blank [ \t]
 literal  \"(\\.|[^\\"])*\"
-stringlit  '[^']*'
 
 %{
   // Code run each time a pattern is matched.
@@ -73,7 +72,6 @@ stringlit  '[^']*'
 <comment>"*"+[^*/\n]*   /* eat up '*'s not followed by '/'s */
 <comment>"*"+"/"        BEGIN(INITIAL);
 <comment><<EOF>>        {
-
                             aalwines::Parser::syntax_error
                                        (builder._location, "Unterminated multiline comment: " + std::string(yytext));
                         }
@@ -132,12 +130,16 @@ stringlit  '[^']*'
     last_string = yytext;
     return token::LITERAL;
 }
-{stringlit}   {
-    last_string = yytext;
-    return token::STRINGLIT;
-}
 {id} {
     last_string = yytext;
     return token::IDENTIFIER;
 }
 
+'[^'\\]*   { last_string = std::string(yytext + 1, yyleng - 1);
+             BEGIN(S_STRING);
+           }
+<S_STRING>{
+  [^'\\]+  { last_string.append(yytext, yyleng); }
+  \\('|\\) { last_string += yytext[1]; }
+  '        { BEGIN(INITIAL); return token::STRINGLIT; }
+}

--- a/src/aalwines/query/QueryLexer.l
+++ b/src/aalwines/query/QueryLexer.l
@@ -41,12 +41,13 @@ using token = aalwines::Parser::token;
 %option yyclass="aalwines::Scanner"
 %x comment
 
-id    [a-zA-Z\_\-][a-zA-Z0-9\_\-']*
+id    [a-zA-Z\_\-][a-zA-Z0-9\_\-]*
 hex   [0-9a-fA-F]
 int   [0-9]+
 float {int}*\.{int}+
 blank [ \t]
 literal  \"(\\.|[^\\"])*\"
+stringlit  '[^']*'
 
 %{
   // Code run each time a pattern is matched.
@@ -130,6 +131,10 @@ literal  \"(\\.|[^\\"])*\"
 {literal}   {
     last_string = yytext;
     return token::LITERAL;
+}
+{stringlit}   {
+    last_string = yytext;
+    return token::STRINGLIT;
 }
 {id} {
     last_string = yytext;

--- a/src/aalwines/query/QueryParser.y
+++ b/src/aalwines/query/QueryParser.y
@@ -89,7 +89,8 @@
         GT        ">"       
         
         IDENTIFIER  "identifier"
-        LITERAL     "literal"        
+        LITERAL     "literal"
+        STRINGLIT   "string literal"
         NUMBER     "number"
         HEX        "hex"
         
@@ -116,7 +117,7 @@
 %type  <Query::mode_t> mode;
 %type  <std::unordered_set<Query::label_t>> atom_list label slabel ip4 ip6;
 %type  <filter_t> atom identifier name;
-%type  <std::string> literal;
+%type  <std::string> literal stringlit;
 //%printer { yyoutput << $$; } <*>;
 %left AND
 %left OR
@@ -237,10 +238,16 @@ literal
     }
     ;
 
+stringlit
+    : STRINGLIT {
+        $$ = scanner.last_string.substr(1, scanner.last_string.length()-2) ;
+    }
+    ;
     
 name
     : IDENTIFIER { $$ = builder.match_exact(scanner.last_string); }
     | literal {  $$ = builder.match_re(std::move($1)); }
+    | stringlit {  $$ = builder.match_exact(std::move($1)); }
     ;
 
 slabel 

--- a/src/aalwines/query/QueryParser.y
+++ b/src/aalwines/query/QueryParser.y
@@ -117,7 +117,7 @@
 %type  <Query::mode_t> mode;
 %type  <std::unordered_set<Query::label_t>> atom_list label slabel ip4 ip6;
 %type  <filter_t> atom identifier name;
-%type  <std::string> literal stringlit;
+%type  <std::string> literal;
 //%printer { yyoutput << $$; } <*>;
 %left AND
 %left OR
@@ -237,17 +237,11 @@ literal
         $$ = scanner.last_string.substr(1, scanner.last_string.length()-2) ;
     }
     ;
-
-stringlit
-    : STRINGLIT {
-        $$ = scanner.last_string.substr(1, scanner.last_string.length()-2) ;
-    }
-    ;
     
 name
     : IDENTIFIER { $$ = builder.match_exact(scanner.last_string); }
     | literal {  $$ = builder.match_re(std::move($1)); }
-    | stringlit {  $$ = builder.match_exact(std::move($1)); }
+    | STRINGLIT {  $$ = builder.match_exact(scanner.last_string); }
     ;
 
 slabel 


### PR DESCRIPTION
Allow router and interfaces names in queries to be specified within single quotes ' '.

In these names, escape ```'``` with ```\'``` and escape ```\``` with ```\\```
