### PR TITLE
Print topology in dot format

### DIFF
--- a/src/aalwines/model/Network.cpp
+++ b/src/aalwines/model/Network.cpp
@@ -207,6 +207,24 @@ namespace aalwines {
         }
         s << "}" << std::endl;
     }
+    void Network::print_dot_topo(std::ostream& s) const {
+        s << "graph network {\n";
+        for (const auto& r : _routers) {
+            if (r->is_null()) continue;
+            bool is_connected = false;
+            for (const auto& i : r->interfaces()) {
+                if (!i->target() || i->target()->is_null() || !i->match()) continue;
+                is_connected = true;
+                // Only make one edge per connected interface pair
+                if (i->match()->global_id() < i->global_id()) continue;
+                s << "\"" << r->name() << "\" -- \"" << i->target()->name() << "\";\n";
+            }
+            if (!is_connected) {
+                s << "\"" << r->name() << "\" [shape=triangle];\n";
+            }
+        }
+        s << "}" << std::endl;
+    }
     void Network::print_simple(std::ostream& s) const {
         for(const auto& r : _routers) {
             s << "router: \"" << r->name() << "\":\n";

--- a/src/aalwines/model/Network.h
+++ b/src/aalwines/model/Network.h
@@ -98,6 +98,7 @@ namespace aalwines {
         static Network make_network(const std::vector<std::string>& names, const std::vector<std::vector<std::string>>& links);
         static Network make_network(const std::vector<std::pair<std::string,Coordinate>>& names, const std::vector<std::vector<std::string>>& links);
         void print_dot(std::ostream& s) const;
+        void print_dot_topo(std::ostream& s) const;
         void print_simple(std::ostream& s) const;
         void print_json(json_stream& json_output) const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,6 +69,7 @@ int main(int argc, const char** argv)
     Verifier verifier("Verification Options");
     
     bool print_dot = false;
+    bool print_dot_topo = false;
     bool print_net = false;
     bool no_parser_warnings = false;
     bool silent = false;
@@ -77,6 +78,7 @@ int main(int argc, const char** argv)
 
     output.add_options()
             ("dot", po::bool_switch(&print_dot), "A dot output will be printed to cout when set.")
+            ("dot-topo", po::bool_switch(&print_dot_topo), "A dot output of the topology will be printed to cout when set.")
             ("net", po::bool_switch(&print_net), "A json output of the network will be printed to cout when set.")
             ("disable-parser-warnings,W", po::bool_switch(&no_parser_warnings), "Disable warnings from parser.")
             ("silent,s", po::bool_switch(&silent), "Disables non-essential output (implies -W).")
@@ -112,6 +114,9 @@ int main(int argc, const char** argv)
 
     if (print_dot) {
         network.print_dot(std::cout);
+    }
+    if (print_dot_topo) {
+        network.print_dot_topo(std::cout);
     }
 
     if (!json_destination.empty()) {


### PR DESCRIPTION
Adds an option `--dot-topo` for printing the topology as an undirected graph without labels on the edges and without edges to nodes outside the network. 
This graph is simpler to overview (but has less information) than the existing `--dot` option.