### PR TITLE
Improve parsing of GML topologies

### DIFF
--- a/src/aalwines/model/Network.cpp
+++ b/src/aalwines/model/Network.cpp
@@ -248,7 +248,7 @@ namespace aalwines {
         network.add_null_router();
         return network;
     }
-    Network Network::make_network(const std::vector<std::pair<std::string,Coordinate>>& names, const std::vector<std::vector<std::string>>& links) {
+    Network Network::make_network(const std::vector<std::pair<std::string,std::optional<Coordinate>>>& names, const std::vector<std::vector<std::string>>& links) {
         Network network;
         std::map<std::string, std::string> _interface_map;
         for (size_t i = 0; i < names.size(); ++i) {

--- a/src/aalwines/model/Network.h
+++ b/src/aalwines/model/Network.h
@@ -96,7 +96,7 @@ namespace aalwines {
         void concat_network(Interface *link, Network &&nested_network, Interface *nested_ingoing, RoutingTable::label_t post_label);
 
         static Network make_network(const std::vector<std::string>& names, const std::vector<std::vector<std::string>>& links);
-        static Network make_network(const std::vector<std::pair<std::string,Coordinate>>& names, const std::vector<std::vector<std::string>>& links);
+        static Network make_network(const std::vector<std::pair<std::string,std::optional<Coordinate>>>& names, const std::vector<std::vector<std::string>>& links);
         void print_dot(std::ostream& s) const;
         void print_simple(std::ostream& s) const;
         void print_json(json_stream& json_output) const;

--- a/src/aalwines/model/builders/TopologyBuilder.cpp
+++ b/src/aalwines/model/builders/TopologyBuilder.cpp
@@ -52,18 +52,26 @@ namespace aalwines {
     Network aalwines::TopologyBuilder::parse(const std::string &gml, std::ostream& warnings) {
         std::ifstream file(gml);
 
-        if(not file){
+        if(!file){
             std::cerr << "Error file not found." << std::endl;
         }
 
-        std::vector<std::pair<size_t, size_t >> _all_links;
-        std::vector<std::pair<std::string, Coordinate>> _all_routers;
-        std::map<const size_t, std::string> _router_map;
+        std::vector<std::pair<size_t, size_t>> _parsed_links;
+        std::vector<std::pair<std::string, std::optional<Coordinate>>> _all_routers;
+        std::unordered_map<size_t, size_t> _index_map; // From 'id' attribute to its index in _all_routers vector.
         std::vector<std::vector<std::string>> _return_links;
+        bool directed = false;
 
         std::string str;
-        while (std::getline(file, str, ' ')) {
-            if(str =="node") {
+        while (std::getline(file >> std::ws, str, ' ')) {
+            trim(str);
+            if (str == "directed") {
+                char next;
+                file >> next;
+                if (next == '1') {
+                    directed = true;
+                }
+            } else if (str =="node") {
                 size_t id;
                 std::string router_name;
                 double latitude = 0;
@@ -73,44 +81,48 @@ namespace aalwines {
                     auto pos = str.find(' ');
                     if (pos == str.size()) continue;
                     std::string key = str.substr(0, pos);
-                    if(key == "id"){
+                    if (key == "id") {
                         id = std::stoul(str.substr(pos+1));
-                    }
-                    else if(key == "label"){
+                    } else if (key == "label") {
                         router_name = str.substr(pos+2, str.size() - pos - 3);
                         trim(router_name);
                         //Get_interface dont handle ' ' very well
                         std::replace(router_name.begin(), router_name.end(), ' ', '_');
                         router_name.erase(std::remove_if(router_name.begin(), router_name.end(),
                                 [](auto const& c) -> bool { return !std::isalnum(c) && c != '_' && c != '-'; }), router_name.end());
-                    }
-                    else if(key == "Latitude"){
+                    } else if (key == "name" && router_name.empty()) { // In some cases we have a 'name' attribute instead of a 'label' attribute.
+                        router_name = str.substr(pos+1);
+                        trim(router_name);
+                        std::replace(router_name.begin(), router_name.end(), ' ', '_');
+                        router_name.erase(std::remove_if(router_name.begin(), router_name.end(),
+                                [](auto const& c) -> bool { return !std::isalnum(c) && c != '_' && c != '-'; }), router_name.end());
+                    } else if (key == "Latitude") {
                         latitude = std::stod(str.substr(pos+1));
-                    }
-                    else if(key == "Longitude"){
+                    } else if (key == "Longitude") {
                         longitude = std::stod(str.substr(pos+1));
-                    }
-                    else if(key == "]"){
-                        bool indexer_active = false;
-                        while (std::find_if( _all_routers.begin(), _all_routers.end(),
-                                [&]( std::pair<std::string,Coordinate> &item ) { return item.first == router_name; } )
-                                != _all_routers.end()) {
-                            if (indexer_active){
-                                if ((int) router_name[router_name.size()-1]++ - 48 > 5) assert(false);
-                            } else {
-                                router_name += "2";
-                                indexer_active = true;
+                    } else if (key == "]") {
+                        if (std::find_if(_all_routers.begin(), _all_routers.end(), // We may have duplicate names, so we find a suffix to make it unique.
+                                         [&](const auto& item){ return item.first == router_name; }) != _all_routers.end()) {
+                            size_t suffix = 2;
+                            std::string new_router_name = router_name + std::to_string(suffix);
+                            while (std::find_if(_all_routers.begin(), _all_routers.end(),
+                                                [&](const auto& item){ return item.first == new_router_name; }) != _all_routers.end()) {
+                                suffix++;
                             }
+                            router_name = new_router_name;
                         }
-                        assert(latitude != 0 or longitude != 0);
-                        _all_routers.emplace_back(router_name, Coordinate{latitude, longitude});
-                        _router_map.insert({id, router_name});
+                        auto index = _all_routers.size();
+                        if(latitude == 0 && longitude == 0) {
+                            _all_routers.emplace_back(router_name, std::nullopt);
+                        } else {
+                            _all_routers.emplace_back(router_name, Coordinate{latitude, longitude});
+                        }
+                        _index_map.emplace(id, index);
                         _return_links.emplace_back();
                         break;
                     }
                 }
-            }
-            else if(str == "edge"){
+            } else if (str == "edge") {
                 size_t source;
                 size_t target;
                 while (std::getline(file, str, ' ')) {
@@ -118,19 +130,19 @@ namespace aalwines {
                         file >> source;
                     } else if (str == "target") {
                         file >> target;
-                        _all_links.emplace_back(source, target);
+                        _parsed_links.emplace_back(source, target);
                         break;
                     }
                 }
             }
         }
 
-        for(size_t i = 0; i < _all_routers.size(); i++){
-            for(auto& link : _all_links){
-                if(link.first == i){
-                    _return_links[i].emplace_back(_router_map[link.second]);
-                    _return_links[link.second].emplace_back(_router_map[link.first]);
-                }
+        for(const auto& link : _parsed_links){
+            auto from_id = _index_map[link.first];
+            auto to_id = _index_map[link.second];
+            _return_links[from_id].emplace_back(_all_routers[to_id].first);
+            if (!directed) {
+                _return_links[to_id].emplace_back(_all_routers[from_id].first);
             }
         }
         return Network::make_network(_all_routers, _return_links);
@@ -138,7 +150,13 @@ namespace aalwines {
 
     inline json to_json_no_routing(const Router& router) {
         auto j = json::object();
-        j["names"] = router.names();
+        j["name"] = router.names().back();
+        if (router.names().size() > 1) {
+            j["alias"] = json::array();
+            for (size_t i = 0; i < router.names().size() - 1; ++i) {
+                j["alias"].emplace_back(router.names()[i]);
+            }
+        }
         j["interfaces"] = json::array();
         for (const auto& interface : router.interfaces()) {
             auto j_i = json::object();


### PR DESCRIPTION
Extend the .gml parser to more topology files.
- Make coordinates optional.
- Parse as a directed graph if `directed 1` is present.
- Use the `name` attribute if no `label` attribute is present.

Also, fix some inconsistencies in the code.