### PR TITLE
Add option --version 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - name: ubuntu install depends
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get install -f build-essential flex bison cmake libboost-all-dev libfl-dev git
+        sudo apt-get install -f build-essential flex bison cmake libboost-all-dev libfl-dev
     - name: Build 
       uses: lukka/run-cmake@v2.5
       with:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,15 +23,26 @@ add_dependencies(aalwines ptrie-ext rapidxml-ext pdaaal-ext)
 target_link_libraries(aalwines PRIVATE ${Boost_LIBRARIES} pdaaal)
 target_include_directories(aalwines PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-find_package(Git)
-add_custom_command(OUTPUT git_hash.h
-		COMMAND ${CMAKE_COMMAND} -E echo_append "#define AALWINES_GIT_HASH " > git_hash.h
-		COMMAND ${GIT_EXECUTABLE} rev-parse HEAD >> git_hash.h
-		COMMAND ${CMAKE_COMMAND} -E echo "#define STRINGIFY(x) #x" >> git_hash.h
-		COMMAND ${CMAKE_COMMAND} -E echo "#define STRINGIGY_MACRO(x) STRINGIFY(x) " >> git_hash.h
-		COMMAND ${CMAKE_COMMAND} -E echo "#define AALWINES_GIT_HASH_STR STRINGIGY_MACRO(AALWINES_GIT_HASH) " >> git_hash.h
-		DEPENDS aalwines main.cpp
-		VERBATIM)
+if(DEFINED ENV{GITHUB_SHA}) # Workaround for Github CI workflow, where the current directory (for some odd reason) is not a git repository.
+	add_custom_command(OUTPUT git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo_append "#define AALWINES_GIT_HASH " > git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo "$ENV{GITHUB_SHA}" >> git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo "#define STRINGIFY(x) #x" >> git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo "#define STRINGIGY_MACRO(x) STRINGIFY(x) " >> git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo "#define AALWINES_GIT_HASH_STR STRINGIGY_MACRO(AALWINES_GIT_HASH) " >> git_hash.h
+			DEPENDS aalwines main.cpp
+			VERBATIM)
+else()
+	find_package(Git)
+	add_custom_command(OUTPUT git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo_append "#define AALWINES_GIT_HASH " > git_hash.h
+			COMMAND ${GIT_EXECUTABLE} rev-parse HEAD >> git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo "#define STRINGIFY(x) #x" >> git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo "#define STRINGIGY_MACRO(x) STRINGIFY(x) " >> git_hash.h
+			COMMAND ${CMAKE_COMMAND} -E echo "#define AALWINES_GIT_HASH_STR STRINGIGY_MACRO(AALWINES_GIT_HASH) " >> git_hash.h
+			DEPENDS aalwines main.cpp
+			VERBATIM)
+endif()
 add_custom_target(generate_hash DEPENDS "git_hash.h")
 add_executable(aalwines-bin main.cpp)
 target_link_libraries(aalwines-bin PRIVATE aalwines)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ add_dependencies(aalwines ptrie-ext rapidxml-ext pdaaal-ext)
 target_link_libraries(aalwines PRIVATE ${Boost_LIBRARIES} pdaaal)
 target_include_directories(aalwines PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+find_package(Git)
 add_custom_command(OUTPUT git_hash.h
 		COMMAND ${CMAKE_COMMAND} -E echo_append "#define AALWINES_GIT_HASH " > git_hash.h
 		COMMAND ${GIT_EXECUTABLE} rev-parse HEAD >> git_hash.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,18 @@ add_dependencies(aalwines ptrie-ext rapidxml-ext pdaaal-ext)
 target_link_libraries(aalwines PRIVATE ${Boost_LIBRARIES} pdaaal)
 target_include_directories(aalwines PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_custom_command(OUTPUT git_hash.h
+		COMMAND ${CMAKE_COMMAND} -E echo_append "#define AALWINES_GIT_HASH " > git_hash.h
+		COMMAND ${GIT_EXECUTABLE} rev-parse HEAD >> git_hash.h
+		COMMAND ${CMAKE_COMMAND} -E echo "#define STRINGIFY(x) #x" >> git_hash.h
+		COMMAND ${CMAKE_COMMAND} -E echo "#define STRINGIGY_MACRO(x) STRINGIFY(x) " >> git_hash.h
+		COMMAND ${CMAKE_COMMAND} -E echo "#define AALWINES_GIT_HASH_STR STRINGIGY_MACRO(AALWINES_GIT_HASH) " >> git_hash.h
+		DEPENDS aalwines main.cpp
+		VERBATIM)
+add_custom_target(generate_hash DEPENDS "git_hash.h")
 add_executable(aalwines-bin main.cpp)
 target_link_libraries(aalwines-bin PRIVATE aalwines)
+add_dependencies(aalwines-bin generate_hash)
 set_target_properties(aalwines-bin PROPERTIES OUTPUT_NAME aalwines)
 install(TARGETS aalwines aalwines-bin
 		RUNTIME DESTINATION bin

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,11 +103,15 @@ int main(int argc, const char** argv)
     po::notify(vm);
 
     if (vm.count("help")) {
-        std::cout << opts << "\n";
+        std::cout << opts << std::endl;
         return 1;
     }
     if (vm.count("version")) {
-        std::cout << "AalWiNes v1.0.0 - git hash: " AALWINES_GIT_HASH_STR << "\n";
+        std::cout << "AalWiNes v1.0.0 - git hash: " AALWINES_GIT_HASH_STR << std::endl
+                  << "Copyright (C) 2021  Peter G. Jensen, Morten K. Schou, Dan Kristiansen, Bernhard C. Schrenk, Kenneth Yrke Jørgensen" << std::endl
+                  << "License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>." << std::endl
+                  << "This is free software: you are free to change and redistribute it." << std::endl
+                  << "There is NO WARRANTY, to the extent permitted by law." << std::endl;
         return 1;
     }
     verifier.check_settings();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@
 #include <string>
 #include <vector>
 #include <fstream>
+#include "git_hash.h" // Generated at build time. Defines AALWINES_GIT_HASH and AALWINES_GIT_HASH_STR 
 
 namespace po = boost::program_options;
 using namespace aalwines;
@@ -62,7 +63,8 @@ int main(int argc, const char** argv)
 {
     po::options_description opts;
     opts.add_options()
-            ("help,h", "produce help message");
+            ("help,h", "produce help message")
+            ("version,v", "print version");
 
     NetworkParsing parser("Input Options");
     po::options_description output("Output Options");
@@ -102,6 +104,10 @@ int main(int argc, const char** argv)
 
     if (vm.count("help")) {
         std::cout << opts << "\n";
+        return 1;
+    }
+    if (vm.count("version")) {
+        std::cout << "AalWiNes v1.0.0 - git hash: " AALWINES_GIT_HASH_STR << "\n";
         return 1;
     }
     verifier.check_settings();


### PR DESCRIPTION
Addresses issue: #89 

Add --version option with semantic versioning (starting at v1.0.0) and git hash computed at build time.
--version also provides copyright and license information similar to many Unix tools.

I don't think --license is a common CLI option, so I suggest keeping that information in the --version option. 