### PR TITLE
Support MessagePack format + read from standard input

### DIFF
--- a/src/aalwines/model/builders/NetworkParsing.cpp
+++ b/src/aalwines/model/builders/NetworkParsing.cpp
@@ -35,11 +35,6 @@ namespace aalwines {
 
     Network NetworkParsing::parse(bool no_warnings) {
 
-        if(json_file.empty() && topo_zoo.empty()) {
-            std::cerr << "Either an AalWiNes json configuration or a .gml topology must be given." << std::endl;
-            exit(-1);
-        }
-
         if(!json_file.empty() && !topo_zoo.empty()) {
             std::cerr << "--input cannot be used with --gml." << std::endl;
             exit(-1);
@@ -48,8 +43,14 @@ namespace aalwines {
         std::stringstream dummy;
         std::ostream& warnings = no_warnings ? dummy : std::cerr;
 
+        auto format = msgpack ? json::input_format_t::msgpack : json::input_format_t::json;
+
         parsing_stopwatch.start();
-        auto network = json_file.empty() ? TopologyBuilder::parse(topo_zoo, warnings) : FastJsonBuilder::parse(json_file, warnings);
+        auto network = !topo_zoo.empty()
+                     ? TopologyBuilder::parse(topo_zoo, warnings)
+                     : ((json_file.empty() || json_file == "-")
+                        ? FastJsonBuilder::parse(std::cin, warnings, format)
+                        : FastJsonBuilder::parse(json_file, warnings, format));
         parsing_stopwatch.stop();
 
         return network;

--- a/src/aalwines/model/builders/NetworkParsing.h
+++ b/src/aalwines/model/builders/NetworkParsing.h
@@ -43,9 +43,9 @@ namespace aalwines {
     public:
         explicit NetworkParsing(const std::string& caption = "Input Options") : input{caption} {
             input.add_options()
-                ("input", po::value<std::string>(&json_file),
-                 "An json-file defining the network in the AalWiNes MPLS Network format")
-                 ("gml", po::value<std::string>(&topo_zoo),"A gml-file defining the topology in the format from topology zoo")
+                ("input", po::value<std::string>(&json_file), "An json-file defining the network in the AalWiNes MPLS Network format. To read from std input specify '--input -'.")
+                ("msgpack", po::bool_switch(&msgpack), "Use the binary MessagePack input format")
+                ("gml", po::value<std::string>(&topo_zoo),"A gml-file defining the topology in the format from topology zoo")
                 ;
         }
 
@@ -55,6 +55,7 @@ namespace aalwines {
 
     private:
         std::string json_file, topo_zoo;
+        bool msgpack = false;
         po::options_description input;
         stopwatch parsing_stopwatch{false};
     };

--- a/src/aalwines/model/builders/NetworkSAXHandler.h
+++ b/src/aalwines/model/builders/NetworkSAXHandler.h
@@ -171,23 +171,23 @@ namespace aalwines {
 
     class FastJsonBuilder {
     public:
-        static Network parse(std::istream& stream, std::ostream& warnings) {
+        static Network parse(std::istream& stream, std::ostream& warnings, json::input_format_t format = json::input_format_t::json) {
             std::stringstream es; // For errors;
             NetworkSAXHandler my_sax(es);
-            if (!json::sax_parse(stream, &my_sax)) {
+            if (!json::sax_parse(stream, &my_sax, format)) {
                 throw base_error(es.str());
             }
             return my_sax.get_network();
         }
 
-        static Network parse(const std::string& network_file, std::ostream& warnings) {
+        static Network parse(const std::string& network_file, std::ostream& warnings, json::input_format_t format = json::input_format_t::json) {
             std::ifstream stream(network_file);
             if (!stream.is_open()) {
                 std::stringstream es;
                 es << "error: Could not open file : " << network_file << std::endl;
                 throw base_error(es.str());
             }
-            return parse(stream, warnings);
+            return parse(stream, warnings, format);
         }
     };
 


### PR DESCRIPTION
With option ```--msgpack``` we now read ```--input``` in the binary MessagePack format instead of plain JSON.
Using ```--input -``` reads from standard input instead of a file.
