### PR TITLE
Virtual link (self-loop) is treated like any other link

### DIFF
--- a/src/aalwines/model/CegarVerifier.h
+++ b/src/aalwines/model/CegarVerifier.h
@@ -97,11 +97,10 @@ namespace aalwines {
                                 return (it == label_map.end() ? 2 : it->second + 3);
                         }
                     },
-                    [&inf_map](const Interface* inf) -> std::tuple<bool, std::vector<edge_t>> {
+                    [&inf_map](const Interface* inf) -> std::vector<edge_t> {
+                        // Use the NFA edges that explicitly mentions inf as the 'abstract state', i.e. group together interfaces that are mentioned similarly.
                         auto it = inf_map.find(inf);
-                        return std::make_tuple(
-                                inf->is_virtual(), // Distinguishing virtual interfaces from non-virtual simplifies the abstraction construction.
-                             (it == inf_map.end()) ? std::vector<edge_t>() : it->second); // Use the NFA edges that explicitly mentions inf as the 'abstract state', i.e. group together interfaces that are mentioned similarly.
+                        return (it == inf_map.end()) ? std::vector<edge_t>() : it->second;
                     }
                 );
                 pdaaal::CEGAR<CegarNetworkPdaFactory<>,CegarNetworkPdaReconstruction<refinement_option>> cegar;

--- a/src/aalwines/model/Network.cpp
+++ b/src/aalwines/model/Network.cpp
@@ -127,7 +127,6 @@ namespace aalwines {
         for (const auto& r : _routers) {
             if (filter._from(r->name())) {
                 for (const auto& i : r->interfaces()) {
-                    if (i->is_virtual()) continue;
                     if (filter._link(r->interface_name(i->id()), i->match()->get_name(), i->target()->name())) {
                         res.insert(i->global_id());
                     }


### PR DESCRIPTION
Previously, links with the same source and target router was explicitly ignored in the query. This behavior is wrong.
If it takes a virtual hop to reach a router with empty stack, then this should be found by a query ending: ' [.#R] < >'.

This also simplifies the code, since all interfaces can be treated the same way. 
